### PR TITLE
Revert "enable actions to run on PRs from forked repositories (#23)"

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -5,6 +5,7 @@ name: Deploy to Firebase Hosting on PR
 "on": pull_request
 jobs:
   build_and_preview:
+    if: "${{ github.event.pull_request.head.repo.full_name == github.repository }}"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This reverts commit 51213fdfc248462c977585ecb8fd5ef99628704c.

I was hoping that commit would allow PRs from forked repositories to run the Cypress tests; there are other limitations, though.