### PR TITLE
shrink height of chadburn container

### DIFF
--- a/src/scenes/Game.module.css
+++ b/src/scenes/Game.module.css
@@ -78,7 +78,7 @@
   position: relative;
   margin: auto;
   width: 300px;
-  height: 300px;
+  height: 180px;
 }
 
 .chadburnImage {
@@ -90,10 +90,14 @@
   display: inline-flex;
   justify-content: center;
   width: 100%;
+  position: relative;
+  z-index: 9;
 }
 
 .actorToggleContainer {
   width: 100%;
   display: inline-flex;
   justify-content: flex-end;
+  position: relative;
+  z-index: 10;
 }


### PR DESCRIPTION
This reduces wasted space on the page and places the spectrum indicators directly below the poles of the half circle