### PR TITLE
use text input for guess form

### DIFF
--- a/src/components/GuessDial.tsx
+++ b/src/components/GuessDial.tsx
@@ -9,13 +9,13 @@ import styles from "../scenes/Game.module.css";
 
 export interface GuessDialProps {
   guess: number;
-  onUpdated: (angle: number) => void;
+  onUpdate: (angle: number) => void;
 }
 /**
  * GuessDial represents the game's guess dial SVG. It restricts its rotation
  * to the top half of a circle.
  */
-export const GuessDial = ({ guess, onUpdated }: GuessDialProps) => {
+export const GuessDial = ({ guess, onUpdate }: GuessDialProps) => {
   // Restrict the rotation angle to -90° < θ < 90°, the top half of a circle
   // (keeping in mind that CSS transforms work clockwise
   // instead of the conventional counter-clockwise).
@@ -44,8 +44,8 @@ export const GuessDial = ({ guess, onUpdated }: GuessDialProps) => {
       style={{
         zIndex: 1,
       }}
-      onUpdated={onUpdated}
-      onUpdating={restrictToUpperHalf}
+      onUpdate={onUpdate}
+      onBeforeUpdate={restrictToUpperHalf}
       angle={guess}
     />
   );

--- a/src/components/RotatableImage.tsx
+++ b/src/components/RotatableImage.tsx
@@ -71,8 +71,8 @@ export interface RotatableImageProps {
   src: string;
   style?: CSSProperties;
   className: string;
-  onUpdated?: (angle: number) => void;
-  onUpdating?: (event: OnUpdatingEvent) => number;
+  onUpdate?: (angle: number) => void;
+  onBeforeUpdate?: (event: OnUpdatingEvent) => number;
 }
 
 /**
@@ -88,8 +88,8 @@ export const RotatableImage = ({
   src,
   className,
   style,
-  onUpdated,
-  onUpdating,
+  onUpdate,
+  onBeforeUpdate,
   angle = START_ANGLE,
 }: RotatableImageProps) => {
   // editModedAngle saves the angle while this component is in 'edit mode'
@@ -138,7 +138,7 @@ export const RotatableImage = ({
     setIsRotating(false);
 
     // when the mouse is released, update the parent
-    if (onUpdated) onUpdated(editModeAngle);
+    if (onUpdate) onUpdate(editModeAngle);
   };
 
   const rotate = (point: Point) => {
@@ -150,8 +150,8 @@ export const RotatableImage = ({
 
       // allow the parent to update the angle e.g. to restrict the range
       // the user can rotate.
-      if (onUpdating) {
-        newAngle = onUpdating({ angle: newAngle, rotationDirection });
+      if (onBeforeUpdate) {
+        newAngle = onBeforeUpdate({ angle: newAngle, rotationDirection });
       }
 
       if (newAngle > editModeAngle) {

--- a/src/scenes/game/Chadburn.tsx
+++ b/src/scenes/game/Chadburn.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { UnselectableImage } from "src/components/UnselectableImage";
 import { GuessDial } from "src/components/GuessDial";
+import { UnselectableImage } from "src/components/UnselectableImage";
 import styles from "../Game.module.css";
 
 export interface ChadburnProps {
   guess: number;
-  onGuessUpdated: (angle: number) => void;
+  onGuessUpdate: (angle: number) => void;
 
   showTarget: boolean;
   target: number;
@@ -19,13 +19,13 @@ export interface ChadburnProps {
  */
 export const Chadburn = ({
   guess,
-  onGuessUpdated,
+  onGuessUpdate,
   showTarget,
   target,
 }: ChadburnProps) => {
   return (
     <div className={styles.chadburn}>
-      <GuessDial guess={guess} onUpdated={onGuessUpdated} />
+      <GuessDial guess={guess} onUpdate={onGuessUpdate} />
       {showTarget && (
         <UnselectableImage
           src="assets/target.svg"

--- a/src/scenes/game/Game.tsx
+++ b/src/scenes/game/Game.tsx
@@ -52,7 +52,7 @@ export const Game = ({ sharedState, publish }: GameProps) => {
     }
   }, [sharedState]);
 
-  const onUpdateGuess = (guess: number) => {
+  const onGuessUpdate = (guess: number) => {
     const action: UpdateGuessAction = {
       type: ActionTypes.UPDATE_GUESS,
       guess,
@@ -60,7 +60,7 @@ export const Game = ({ sharedState, publish }: GameProps) => {
     publish(action);
   };
 
-  const onUpdateHint = (hint: string) => {
+  const onHintUpdate = (hint: string) => {
     const action: UpdateHintAction = {
       type: ActionTypes.UPDATE_HINT,
       hint,
@@ -68,7 +68,7 @@ export const Game = ({ sharedState, publish }: GameProps) => {
     publish(action);
   };
 
-  const onSubmitHint = () => {
+  const onHintSubmit = () => {
     const action: SubmitHintAction = {
       type: ActionTypes.SUBMIT_HINT,
       hint: sharedState.hint || "",
@@ -76,7 +76,7 @@ export const Game = ({ sharedState, publish }: GameProps) => {
     publish(action);
   };
 
-  const onToggleActor = (isPlayer: boolean) => {
+  const onActorToggle = (isPlayer: boolean) => {
     setIsPlayer(isPlayer);
   };
 
@@ -96,7 +96,7 @@ export const Game = ({ sharedState, publish }: GameProps) => {
     publish({ type: ActionTypes.UPDATE_REBUTTAL, rebuttal });
   };
 
-  const onSubmitRebuttal = () => {
+  const onRebuttalSubmit = () => {
     const action: SubmitRebuttalAction = {
       type: ActionTypes.SUBMIT_REBUTTAL,
       rebuttal: sharedState.rebuttal ? sharedState.rebuttal : DEFAULT_REBUTTAL,
@@ -118,16 +118,16 @@ export const Game = ({ sharedState, publish }: GameProps) => {
   let currentActionForm = (
     <HintForm
       hint={sharedState.hint || ""}
-      onHintUpdated={onUpdateHint}
-      onHintSubmitted={onSubmitHint}
+      onHintUpdate={onHintUpdate}
+      onHintSubmit={onHintSubmit}
     />
   );
   if (sharedState.game.turn.hint && sharedState.game.turn.guess === undefined) {
     currentActionForm = (
       <GuessForm
         guess={sharedState.guess}
-        onGuessUpdated={onUpdateGuess}
-        onGuessSubmitted={onGuessSubmit}
+        onGuessUpdate={onGuessUpdate}
+        onGuessSubmit={onGuessSubmit}
       />
     );
     currentActionFormVisible = isPlayer;
@@ -143,7 +143,7 @@ export const Game = ({ sharedState, publish }: GameProps) => {
         teamInTurn={sharedState.game.teamInTurn}
         otherTeam={getTeamOutOfTurn(sharedState.game)}
         onRebuttalUpdate={onRebuttalUpdate}
-        onRebuttalSubmit={onSubmitRebuttal}
+        onRebuttalSubmit={onRebuttalSubmit}
       />
     );
     currentActionFormVisible = isPlayer;
@@ -162,7 +162,7 @@ export const Game = ({ sharedState, publish }: GameProps) => {
 
       <Chadburn
         guess={sharedState.guess}
-        onGuessUpdated={onUpdateGuess}
+        onGuessUpdate={onGuessUpdate}
         showTarget={!isPlayer || turnOver}
         target={sharedState.game.turn.target}
       />
@@ -179,7 +179,7 @@ export const Game = ({ sharedState, publish }: GameProps) => {
       <div className={styles.actorToggleContainer}>
         <Footer
           isPlayer={isPlayer}
-          onActorToggle={onToggleActor}
+          onActorToggle={onActorToggle}
           onNewGameClick={onNewGameClick}
         />
       </div>

--- a/src/scenes/game/GuessForm.tsx
+++ b/src/scenes/game/GuessForm.tsx
@@ -20,6 +20,13 @@ export const GuessForm = ({
   const onInputChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     let newGuess = event.target.value;
 
+    /**
+     * Only propagate the update upward if it is a valid number.
+     * Otherwise, keep the update local to allow the user to fix it.
+     *
+     * e.g. if they type '-', don't propagate NaN upward. Let the user
+     * finish typing '-10'.
+     */
     if (!isGuessInvalid(newGuess)) {
       const newGuessAsNumber = Number(newGuess);
       if (newGuessAsNumber > 90) newGuess = String(90);
@@ -34,14 +41,17 @@ export const GuessForm = ({
     return isNaN(Number(guess)) || guess === "";
   };
 
+  /**
+   * Use input with type="text" because built-in number inputs suck.
+   * Their validation happens too early, so they don't allow the user to
+   * 'finish their thought'.
+   *
+   * The main issue is, users cannot fully clear (using backspace) the text box, making entering negative
+   * numbers difficult.
+   */
   return (
     <>
-      <input
-        inputMode="decimal"
-        type="text"
-        value={localGuess}
-        onChange={onInputChange}
-      />
+      <input type="text" value={localGuess} onChange={onInputChange} />
       <button onClick={onGuessSubmitted} disabled={isGuessInvalid(localGuess)}>
         Submit
       </button>

--- a/src/scenes/game/GuessForm.tsx
+++ b/src/scenes/game/GuessForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 export interface GuessFormProps {
   guess: number;
@@ -11,14 +11,40 @@ export const GuessForm = ({
   onGuessUpdated,
   onGuessSubmitted,
 }: GuessFormProps) => {
-  const onInputChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    onGuessUpdated(Number(event.target.value));
+  const [localGuess, setLocalGuess] = useState<string>(String(guess));
+
+  useEffect(() => {
+    setLocalGuess(String(guess));
+  }, [guess]);
+
+  const onInputChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    let newGuess = event.target.value;
+
+    if (!isGuessInvalid(newGuess)) {
+      const newGuessAsNumber = Number(newGuess);
+      if (newGuessAsNumber > 90) newGuess = String(90);
+      if (newGuessAsNumber < -90) newGuess = String(-90);
+      onGuessUpdated(Number(newGuess));
+    }
+
+    setLocalGuess(newGuess);
+  };
+
+  const isGuessInvalid = (guess: string) => {
+    return isNaN(Number(guess)) || guess === "";
   };
 
   return (
     <>
-      <input type="number" value={guess} onChange={onInputChanged} />
-      <button onClick={onGuessSubmitted}>Submit</button>
+      <input
+        inputMode="decimal"
+        type="text"
+        value={localGuess}
+        onChange={onInputChange}
+      />
+      <button onClick={onGuessSubmitted} disabled={isGuessInvalid(localGuess)}>
+        Submit
+      </button>
     </>
   );
 };

--- a/src/scenes/game/GuessForm.tsx
+++ b/src/scenes/game/GuessForm.tsx
@@ -2,14 +2,14 @@ import React, { useEffect, useState } from "react";
 
 export interface GuessFormProps {
   guess: number;
-  onGuessUpdated: (guess: number) => void;
-  onGuessSubmitted: () => void;
+  onGuessUpdate: (guess: number) => void;
+  onGuessSubmit: () => void;
 }
 
 export const GuessForm = ({
   guess,
-  onGuessUpdated,
-  onGuessSubmitted,
+  onGuessUpdate,
+  onGuessSubmit,
 }: GuessFormProps) => {
   const [localGuess, setLocalGuess] = useState<string>(String(guess));
 
@@ -31,7 +31,7 @@ export const GuessForm = ({
       const newGuessAsNumber = Number(newGuess);
       if (newGuessAsNumber > 90) newGuess = String(90);
       if (newGuessAsNumber < -90) newGuess = String(-90);
-      onGuessUpdated(Number(newGuess));
+      onGuessUpdate(Number(newGuess));
     }
 
     setLocalGuess(newGuess);
@@ -52,7 +52,7 @@ export const GuessForm = ({
   return (
     <>
       <input type="text" value={localGuess} onChange={onInputChange} />
-      <button onClick={onGuessSubmitted} disabled={isGuessInvalid(localGuess)}>
+      <button onClick={onGuessSubmit} disabled={isGuessInvalid(localGuess)}>
         Submit
       </button>
     </>

--- a/src/scenes/game/HintForm.tsx
+++ b/src/scenes/game/HintForm.tsx
@@ -2,17 +2,17 @@ import React from "react";
 
 export interface HintFormProps {
   hint: string;
-  onHintUpdated: (hint: string) => void;
-  onHintSubmitted: () => void;
+  onHintUpdate: (hint: string) => void;
+  onHintSubmit: () => void;
 }
 
 export const HintForm = ({
   hint,
-  onHintUpdated,
-  onHintSubmitted,
+  onHintUpdate,
+  onHintSubmit,
 }: HintFormProps) => {
   const onInputChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    onHintUpdated(event.target.value);
+    onHintUpdate(event.target.value);
   };
 
   return (
@@ -23,7 +23,7 @@ export const HintForm = ({
         onChange={onInputChanged}
         value={hint}
       ></input>
-      <button disabled={hint === ""} onClick={onHintSubmitted}>
+      <button disabled={hint === ""} onClick={onHintSubmit}>
         Submit
       </button>
     </div>


### PR DESCRIPTION
use input of type `text` because built-in number inputs suck. Their validation happens too early, so they don't allow the user to 'finish their thought'. The main issue is, users cannot fully clear (using backspace) the text box, making entering negative numbers difficult.