### PR TITLE
shorten game IDs to make them more human readable

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "react-icons": "^4.7.1",
     "react-router": "^6.6.1",
     "react-router-dom": "^6.6.1",
-    "uuid": "^9.0.0",
     "y-webrtc": "^10.2.3",
     "yjs": "^13.5.42"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "esbuild": "^0.15.13",
     "esbuild-css-modules-plugin": "^2.6.3",
     "jest-environment-jsdom": "^29.4.0",
+    "nanoid": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ specifiers:
   husky-init: ^8.0.0
   jest: ^29.3.1
   jest-environment-jsdom: ^29.4.0
+  nanoid: ^4.0.0
   prettier: ^2.7.1
   react: ^18.2.0
   react-dom: ^18.2.0
@@ -44,6 +45,7 @@ dependencies:
   esbuild: 0.15.13
   esbuild-css-modules-plugin: 2.6.3_esbuild@0.15.13
   jest-environment-jsdom: 29.4.0
+  nanoid: 4.0.0
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
   react-icons: 4.7.1_react@18.2.0
@@ -883,7 +885,7 @@ packages:
     resolution: {integrity: sha512-VaywcGQ9tPorCX/Jkkni7RWGFfI11whqzs8dvxF41P17Z+z872thvEvlIbznjPJ02kl1HMX3LmLOonsj2n7HeQ==}
     dependencies:
       expect: 29.3.1
-      pretty-format: 29.3.1
+      pretty-format: 29.4.0
     dev: true
 
   /@types/jsdom/20.0.1:
@@ -4256,6 +4258,12 @@ packages:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  /nanoid/4.0.0:
+    resolution: {integrity: sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==}
+    engines: {node: ^14 || ^16 || >=18}
+    hasBin: true
+    dev: false
 
   /natural-compare-lite/1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,6 @@ specifiers:
   react-router-dom: ^6.6.1
   typescript: ^4.8.4
   typescript-plugin-css-modules: ^4.1.1
-  uuid: ^9.0.0
   y-webrtc: ^10.2.3
   yjs: ^13.5.42
 
@@ -51,7 +50,6 @@ dependencies:
   react-icons: 4.7.1_react@18.2.0
   react-router: 6.6.1_react@18.2.0
   react-router-dom: 6.6.1_biqbaboplfbrettd7655fr4n2y
-  uuid: 9.0.0
   y-webrtc: 10.2.3
   yjs: 13.5.42
 
@@ -5462,11 +5460,6 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
     dev: true
-
-  /uuid/9.0.0:
-    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
-    hasBin: true
-    dev: false
 
   /v8-to-istanbul/9.0.1:
     resolution: {integrity: sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==}

--- a/src/scenes/Landing.tsx
+++ b/src/scenes/Landing.tsx
@@ -3,6 +3,11 @@ import React from "react";
 import { useNavigate } from "react-router";
 import styles from "./Landing.module.css";
 
+/**
+ * generateId generates URL-safe IDs which are 5 characters long.
+ * These IDs should uniquely identify each game while being
+ * human readable and memorable.
+ */
 const generateId = customAlphabet(urlAlphabet, 5);
 
 export const Landing = () => {

--- a/src/scenes/Landing.tsx
+++ b/src/scenes/Landing.tsx
@@ -1,13 +1,16 @@
+import { customAlphabet, urlAlphabet } from "nanoid";
 import React from "react";
 import { useNavigate } from "react-router";
-import { v4 as uuidv4 } from "uuid";
 import styles from "./Landing.module.css";
+
+const generateId = customAlphabet(urlAlphabet, 5);
 
 export const Landing = () => {
   const navigate = useNavigate();
 
+  console.log(urlAlphabet);
   const onClick = () => {
-    navigate(`/${uuidv4()}`, { replace: true });
+    navigate(`/${generateId()}`, { replace: true });
   };
 
   return (

--- a/src/scenes/Landing.tsx
+++ b/src/scenes/Landing.tsx
@@ -13,7 +13,6 @@ const generateId = customAlphabet(urlAlphabet, 5);
 export const Landing = () => {
   const navigate = useNavigate();
 
-  console.log(urlAlphabet);
   const onClick = () => {
     navigate(`/${generateId()}`, { replace: true });
   };

--- a/src/scenes/Landing.tsx
+++ b/src/scenes/Landing.tsx
@@ -4,11 +4,11 @@ import { useNavigate } from "react-router";
 import styles from "./Landing.module.css";
 
 /**
- * generateId generates URL-safe IDs which are 5 characters long.
+ * generateId generates URL-safe IDs which are 4 characters long.
  * These IDs should uniquely identify each game while being
  * human readable and memorable.
  */
-const generateId = customAlphabet(urlAlphabet, 5);
+const generateId = customAlphabet(urlAlphabet, 4);
 
 export const Landing = () => {
   const navigate = useNavigate();


### PR DESCRIPTION
Replace the long (32 characters?) `uuid`s with shorter 4-character IDs generated with [`nanoid`](https://github.com/ai/nanoid).

These IDs use the `urlAlphabet` so they should be suitable for our uses. This alphabet contains 64 characters, so our 4-character ID space should have over 16 million IDs.