### PR TITLE
moving New Game button back to the bottom; making it an anchor to sav…

### DIFF
--- a/src/Styles/App.scss
+++ b/src/Styles/App.scss
@@ -25,6 +25,10 @@ body {
   max-width: 525px;
 }
 
+a {
+  cursor: pointer;
+}
+
 button,
 input {
   font-family: inherit;

--- a/src/scenes/Game.module.scss
+++ b/src/scenes/Game.module.scss
@@ -2,14 +2,6 @@
   display: block;
 }
 
-.newGameContainer {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-top: -30px;
-  margin-bottom: 20px;
-}
-
 .pageHeader {
   display: flex;
   justify-content: left;
@@ -118,9 +110,11 @@
 .actorToggleContainer {
   width: 100%;
   display: inline-flex;
-  justify-content: right;
+  justify-content: space-between;
   position: relative;
   z-index: 10;
   margin-right: 10px;
+  margin-left: 10px;
   margin-top: 20px;
+  align-items: center;
 }

--- a/src/scenes/game/Footer.tsx
+++ b/src/scenes/game/Footer.tsx
@@ -9,9 +9,14 @@ export interface FooterProps {
   onNewGameClick: () => void;
 }
 
-export const Footer = ({ isPlayer, onActorToggle }: FooterProps) => {
+export const Footer = ({
+  isPlayer,
+  onActorToggle,
+  onNewGameClick,
+}: FooterProps) => {
   return (
     <div className="actorToggleContainer">
+      <a onClick={onNewGameClick}>New Game</a>
       <Toggle
         left="Player"
         right="Psychic"

--- a/src/scenes/game/Game.tsx
+++ b/src/scenes/game/Game.tsx
@@ -151,10 +151,6 @@ export const Game = ({ sharedState, publish }: GameProps) => {
 
   return (
     <div className="gameSceneContainer" draggable={false}>
-      <div className="newGameContainer">
-        <button onClick={onNewGameClick}>New Game</button>
-      </div>
-
       <Header
         score={sharedState.game.score}
         teamInTurn={sharedState.game.teamInTurn}


### PR DESCRIPTION
…e space

I moved the New Game button back to the bottom to save vertical space, which we can use to add a 'draw new spectrum' button and separate the other components a little more.

We were concerned about the footer getting too crowded, so I made this button an anchor to make it less crowded.