### PR TITLE
Adding e2e tests for multiplayer support

### DIFF
--- a/cypress/e2e/game.cy.js
+++ b/cypress/e2e/game.cy.js
@@ -9,47 +9,47 @@ describe("game", () => {
     cy.startNewGame();
 
     // blue team turn 1
-    Psychic.setsHint("a hint");
-    Player.setsGuessForPoints(4);
-    Player.choosesIncorrectRebuttal();
+    Psychic.submitsHint("a hint");
+    Player.submitsGuessForPoints(4);
+    Player.submitsIncorrectRebuttal();
     Game.getScoreForTeam(Teams.BLUE).should("equal", "4");
     Game.getScoreForTeam(Teams.RED).should("equal", "0");
 
     // red team turn 1
-    Psychic.setsHint("a hint");
-    Player.setsGuessForPoints(2);
-    Player.choosesCorrectRebuttal();
+    Psychic.submitsHint("a hint");
+    Player.submitsGuessForPoints(2);
+    Player.submitsCorrectRebuttal();
 
     Game.getScoreForTeam(Teams.BLUE).should("equal", "5");
     Game.getScoreForTeam(Teams.RED).should("equal", "2");
 
     // blue team turn 2
-    Psychic.setsHint("a hint");
-    Player.setsGuessForPoints(3);
-    Player.choosesCorrectRebuttal();
+    Psychic.submitsHint("a hint");
+    Player.submitsGuessForPoints(3);
+    Player.submitsCorrectRebuttal();
     Game.getScoreForTeam(Teams.BLUE).should("equal", "8");
     Game.getScoreForTeam(Teams.RED).should("equal", "3");
 
     // red team turn 2
-    Psychic.setsHint("a hint");
-    Player.setsGuessForPoints(4);
-    Player.choosesIncorrectRebuttal();
+    Psychic.submitsHint("a hint");
+    Player.submitsGuessForPoints(4);
+    Player.submitsIncorrectRebuttal();
 
     Game.getScoreForTeam(Teams.BLUE).should("equal", "8");
     Game.getScoreForTeam(Teams.RED).should("equal", "7");
 
     // red team catch up turn
-    Psychic.setsHint("a hint");
-    Player.setsGuessForPoints(0);
-    Player.choosesCorrectRebuttal();
+    Psychic.submitsHint("a hint");
+    Player.submitsGuessForPoints(0);
+    Player.submitsCorrectRebuttal();
 
     Game.getScoreForTeam(Teams.BLUE).should("equal", "9");
     Game.getScoreForTeam(Teams.RED).should("equal", "7");
 
     // blue team turn 3
-    Psychic.setsHint("a hint");
-    Player.setsGuessForPoints(2);
-    Player.choosesCorrectRebuttal();
+    Psychic.submitsHint("a hint");
+    Player.submitsGuessForPoints(2);
+    Player.submitsCorrectRebuttal();
 
     Game.getScoreForTeam(Teams.BLUE).should("equal", "11");
     Game.getScoreForTeam(Teams.RED).should("equal", "8");
@@ -60,7 +60,7 @@ describe("game", () => {
 
     const hint = "a hint";
     const guess = 25;
-    Psychic.setsHint(hint);
+    Psychic.submitsHint(hint);
     Player.setsGuess(guess);
 
     const oldSpectrumAlias = "old-spectrum";

--- a/cypress/e2e/multiplayer.cy.js
+++ b/cypress/e2e/multiplayer.cy.js
@@ -77,6 +77,31 @@ describe("multiplayer", () => {
       otherPlayer.setGuess(guess);
     });
 
-    Game.getGuessAngle().should("equal", 88);
+    Game.getGuessAngle().should("equal", guess);
   });
+
+  /*
+  TODO enable this test when we fix the multiplayer cache overwriting issue
+  it("leaves behind its cached state when joining another player's game", () => {
+    cy.startNewGame();
+    Psychic.submitsHint("a hint");
+    Player.setsGuess(11);
+
+    const otherGameId = "otherGame";
+    const otherPlayer = getClientForAnotherPlayer(
+      otherGameId,
+      getDefaultSignalingUrl()
+    );
+
+    const newGuess = 22;
+    const newHint = "new hint";
+    otherPlayer.setGuess(newGuess);
+    otherPlayer.setSubmittedHint(newHint);
+
+    cy.visit(`/${otherGameId}`);
+
+    Game.getGuessAngle().should("equal", newGuess);
+    Game.getSubmittedHint().should("equal", newHint);
+  });
+  */
 });

--- a/cypress/e2e/multiplayer.cy.js
+++ b/cypress/e2e/multiplayer.cy.js
@@ -1,0 +1,40 @@
+/// <reference types="Cypress" />
+
+import { Game } from "../lib/Game";
+import {
+  getClientForAnotherPlayer,
+  getDefaultSignalingUrl,
+} from "../lib/Multiplayer";
+import { Psychic } from "../lib/Psychic";
+
+describe("multiplayer", () => {
+  it("shares updates between players", () => {
+    cy.startNewGame();
+
+    const otherPlayerAlias = "other-player";
+
+    Game.getId().then((gameId) => {
+      const otherPlayer = getClientForAnotherPlayer(
+        gameId,
+        getDefaultSignalingUrl()
+      );
+      console.log("created other player");
+      cy.wrap(otherPlayer).as(otherPlayerAlias);
+    });
+
+    const hint = "a hint";
+    Psychic.setsHint(hint);
+    console.log("set hint");
+
+    /*
+    TODO multiplayer is completely broken ATM - updates to the dial, the spectra, etc. - nothing is synchronized currently.
+    websocket traffic does not seem to be carrying updates, but I need to look into this more (I could be misreading things)
+    It is difficult to make progress with these tests in such a state. 
+    The next step is probably to use git bisect or something to identify when all of this shit broke.
+    */
+
+    cy.get(`@${otherPlayerAlias}`).then((otherPlayer) => {
+      cy.wrap(otherPlayer.getSubmittedHint()).should("equal", hint);
+    });
+  });
+});

--- a/cypress/lib/Game.js
+++ b/cypress/lib/Game.js
@@ -41,6 +41,21 @@ function getRotationDegreesFromCssMatrix(cssMatrix) {
   return normalizeDegrees(angle < 0 ? angle + 360 : angle);
 }
 
+export function getAngleOfElement($element) {
+  const transform = $element.css("transform");
+  let angle = NaN;
+
+  if (rotateDegreeRegex.test(transform)) {
+    const match = rotateDegreeRegex.exec(transform);
+    angle = match[1];
+  } else if (matrixRegx.test(transform)) {
+    const match = matrixRegx.exec(transform);
+    angle = getRotationDegreesFromCssMatrix(match[0]);
+  }
+
+  return angle;
+}
+
 export const Game = {
   enablePsychicView() {
     return cy.contains("button", "Psychic").then(($btn) => {
@@ -60,20 +75,7 @@ export const Game = {
     return cy.get('img[src="assets/guess.svg"]');
   },
   getGuessAngle() {
-    return Game.getGuessDial().then(($guessDial) => {
-      const transform = $guessDial.css("transform");
-      let angle = NaN;
-
-      if (rotateDegreeRegex.test(transform)) {
-        const match = rotateDegreeRegex.exec(transform);
-        angle = match[1];
-      } else if (matrixRegx.test(transform)) {
-        const match = matrixRegx.exec(transform);
-        angle = getRotationDegreesFromCssMatrix(match[0]);
-      }
-
-      return cy.wrap(angle);
-    });
+    return Game.getGuessDial().pipe(getAngleOfElement);
   },
   getTargetImage() {
     return cy.get('img[src="assets/target.svg"]');

--- a/cypress/lib/Game.js
+++ b/cypress/lib/Game.js
@@ -154,4 +154,9 @@ export const Game = {
       return cy.wrap($scoreSpan.text());
     });
   },
+  getId() {
+    return cy.location().then((location) => {
+      return cy.wrap(location.pathname);
+    });
+  },
 };

--- a/cypress/lib/Game.js
+++ b/cypress/lib/Game.js
@@ -156,7 +156,7 @@ export const Game = {
   },
   getId() {
     return cy.location().then((location) => {
-      return cy.wrap(location.pathname);
+      return cy.wrap(location.pathname.slice(1));
     });
   },
 };

--- a/cypress/lib/Multiplayer.js
+++ b/cypress/lib/Multiplayer.js
@@ -58,4 +58,8 @@ export class MultiplayerClient {
   setGuess(guess) {
     this.ymap.set("guess", guess);
   }
+
+  setSubmittedHint(hint) {
+    return this.ymap.get("game")?.get("turn")?.set("hint", hint);
+  }
 }

--- a/cypress/lib/Multiplayer.js
+++ b/cypress/lib/Multiplayer.js
@@ -25,7 +25,6 @@ export function getDefaultSignalingUrl() {
  * @returns
  */
 export function getClientForAnotherPlayer(gameId, signalingUrl) {
-  console.log(gameId, signalingUrl);
   const ydoc = new Y.Doc();
 
   const provider = new WebrtcProvider(gameId, ydoc, {
@@ -37,23 +36,26 @@ export function getClientForAnotherPlayer(gameId, signalingUrl) {
 
 const SHARED_STATE_YMAP_NAME = "sharedState";
 
+/**
+ * MultiplayerClient represents another player.
+ * It can be used to perform actions on behalf of another player and query the other player's game state.
+ */
 export class MultiplayerClient {
   constructor(ydoc, provider) {
     this.ydoc = ydoc;
     this.provider = provider;
     this.ymap = this.ydoc.getMap(SHARED_STATE_YMAP_NAME);
-
-    this.ydoc.on("beforeTransaction", (event) => {
-      console.log(event);
-    });
-
-    this.ymap.observeDeep(() => {
-      console.log("an update happened");
-    });
   }
 
   getSubmittedHint() {
-    console.log(this.ymap.toJSON());
     return this.ymap.get("game")?.get("turn")?.get("hint");
+  }
+
+  getGuess() {
+    return this.ymap.get("guess");
+  }
+
+  setGuess(guess) {
+    this.ymap.set("guess", guess);
   }
 }

--- a/cypress/lib/Player.js
+++ b/cypress/lib/Player.js
@@ -1,31 +1,34 @@
 import { Game } from "./Game";
 
 export const Player = {
-  setsGuessForPoints(points) {
-    Game.getGuessForPoints(points).then((guessAngle) => {
-      Player.setsGuess(guessAngle);
-    });
-  },
   setsGuess(guess) {
     Game.enablePlayerView();
     cy.get('[data-cy="game_input_guess"]').clear().type(guess);
+  },
+  submitsGuessForPoints(points) {
+    Game.getGuessForPoints(points).then((guessAngle) => {
+      Player.submitsGuess(guessAngle);
+    });
+  },
+  submitsGuess(guess) {
+    Player.setsGuess(guess);
     cy.get('[data-cy="game_btn_submit_guess"]').click();
   },
-  choosesRebuttalWithCorrectness(correct) {
+  submitsRebuttalWithCorrectness(correct) {
     let rebuttalFunction = correct
       ? Game.getCorrectRebuttal
       : Game.getIncorrectRebuttal;
     rebuttalFunction().then((rebuttal) => {
-      Player.choosesRebuttal(rebuttal);
+      Player.submitsRebuttal(rebuttal);
     });
   },
-  choosesCorrectRebuttal() {
-    Player.choosesRebuttalWithCorrectness(true);
+  submitsCorrectRebuttal() {
+    Player.submitsRebuttalWithCorrectness(true);
   },
-  choosesIncorrectRebuttal() {
-    Player.choosesRebuttalWithCorrectness(false);
+  submitsIncorrectRebuttal() {
+    Player.submitsRebuttalWithCorrectness(false);
   },
-  choosesRebuttal(rebuttal) {
+  submitsRebuttal(rebuttal) {
     Game.enablePlayerView();
     cy.contains("button", rebuttal).then(($btn) => {
       if (!$btn.is(":disabled")) {

--- a/cypress/lib/Psychic.js
+++ b/cypress/lib/Psychic.js
@@ -1,7 +1,7 @@
 import { Game } from "./Game";
 
 export const Psychic = {
-  setsHint(hint) {
+  submitsHint(hint) {
     Game.enablePsychicView();
     cy.get('[data-cy="game_input_hint"]').clear().type(hint);
     cy.get('[data-cy="game_btn_submit_hint"]').click();

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -14,6 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
+import "cypress-pipe";
 import "./commands";
 
 // Alternatively you can use CommonJS syntax:

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "@typescript-eslint/parser": "^5.50.0",
     "cypress": "^12.5.1",
+    "cypress-pipe": "^2.0.0",
     "esbuild-jest-transform": "^1.1.1",
     "eslint": "^8.33.0",
     "eslint-config-prettier": "^8.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ specifiers:
   '@typescript-eslint/parser': ^5.50.0
   concurrently: ^7.6.0
   cypress: ^12.5.1
+  cypress-pipe: ^2.0.0
   esbuild: ^0.15.18
   esbuild-jest-transform: ^1.1.1
   esbuild-sass-plugin: ^2.4.5
@@ -59,6 +60,7 @@ devDependencies:
   '@typescript-eslint/eslint-plugin': 5.50.0_go4drrxstycfikanvu45pi4vgq
   '@typescript-eslint/parser': 5.50.0_4vsywjlpuriuw3tl5oq6zy5a64
   cypress: 12.5.1
+  cypress-pipe: 2.0.0
   esbuild-jest-transform: 1.1.1_esbuild@0.15.18
   eslint: 8.33.0
   eslint-config-prettier: 8.6.0_eslint@8.33.0
@@ -1782,6 +1784,10 @@ packages:
   /csstype/3.1.1:
     resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
     dev: false
+
+  /cypress-pipe/2.0.0:
+    resolution: {integrity: sha512-KW9s+bz4tFLucH3rBGfjW+Q12n7S4QpUSSyxiGrgPOfoHlbYWzAGB3H26MO0VTojqf9NVvfd5Kt0MH5XMgbfyg==}
+    dev: true
 
   /cypress/12.5.1:
     resolution: {integrity: sha512-ZmCmJ3lsyeOpBfh410m5+AO2CO1AxAzFBt7k6/uVbNcrNZje1vdiwYTpj2ksPKg9mjr9lR6V8tmlDNMvr4H/YQ==}


### PR DESCRIPTION
These tests use an in-process Y document to simulate another player in the Cypress test. This is necessary because Cypress only allows one browser tab to be open at a time.