### PR TITLE
support for a free play mode

### DIFF
--- a/cypress/e2e/free_play.cy.js
+++ b/cypress/e2e/free_play.cy.js
@@ -1,0 +1,30 @@
+/// <reference types="Cypress" />
+
+import { Teams } from "../lib/Game";
+import { Player } from "../lib/Player";
+import { Psychic } from "../lib/Psychic";
+
+describe("game", () => {
+  it("does not display score", () => {
+    cy.startFreePlay();
+
+    cy.get("[data-cy='game_header']").should("not.be.visible");
+  });
+
+  it("does not display team names in the rebuttal prompt", () => {
+    cy.startFreePlay();
+
+    Psychic.submitsHint("a hint");
+    Player.submitsGuessForPoints(4);
+
+    cy.get("[data-cy='game_prompt_rebuttal']").should(
+      "not.contain.text",
+      Teams.BLUE
+    );
+
+    cy.get("[data-cy='game_prompt_rebuttal']").should(
+      "not.contain.text",
+      Teams.RED
+    );
+  });
+});

--- a/cypress/e2e/guess_dial.cy.js
+++ b/cypress/e2e/guess_dial.cy.js
@@ -1,6 +1,26 @@
 /// <reference types="Cypress" />
 
 import { Game } from "../lib/Game";
+import { Player } from "../lib/Player";
+import { Psychic } from "../lib/Psychic";
+
+const moveDial = () => {
+  Game.getGuessDial().then(($guessDial) => {
+    const offset = $guessDial.offset();
+
+    const downX = $guessDial.width() / 2 + offset.left;
+    const downY = $guessDial.height() / 4 + offset.top;
+
+    cy.wrap($guessDial)
+      .trigger("mousedown", { clientX: downX, clientY: downY, which: 1 })
+      .trigger("mousemove", {
+        clientX: downX - 10,
+        clientY: downY,
+        which: 1,
+      })
+      .trigger("mouseup");
+  });
+};
 
 /**
  * Smoke tests for the SVG guess dial. We need to ensure it can be dragged.
@@ -11,22 +31,35 @@ describe("guess dial", () => {
 
     Game.getGuessAngle().should("equal", 0);
 
-    Game.getGuessDial().then(($guessDial) => {
-      const offset = $guessDial.offset();
-
-      const downX = $guessDial.width() / 2 + offset.left;
-      const downY = $guessDial.height() / 4 + offset.top;
-
-      cy.wrap($guessDial)
-        .trigger("mousedown", { clientX: downX, clientY: downY, which: 1 })
-        .trigger("mousemove", {
-          clientX: downX - 10,
-          clientY: downY,
-          which: 1,
-        })
-        .trigger("mouseup");
-    });
+    moveDial();
 
     Game.getGuessAngle().should("not.equal", 0);
+  });
+
+  it("cannot be rotated during rebuttal", () => {
+    [cy.startNewGame, cy.startFreePlay].forEach((modeFunc) => {
+      modeFunc();
+
+      Psychic.submitsHint("a hint");
+      Player.submitsGuess(0);
+
+      moveDial();
+
+      Game.getGuessAngle().should("eq", 0);
+    });
+  });
+
+  it("cannot be rotated during turn summary", () => {
+    [cy.startNewGame, cy.startFreePlay].forEach((modeFunc) => {
+      modeFunc();
+
+      Psychic.submitsHint("a hint");
+      Player.submitsGuess(0);
+      Player.submitsRebuttalWithCorrectness(true);
+
+      moveDial();
+
+      Game.getGuessAngle().should("eq", 0);
+    });
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -40,3 +40,8 @@ Cypress.Commands.add("startNewGame", () => {
   cy.visit("/");
   cy.get('[data-cy="landing_btn_new_game"]').click();
 });
+
+Cypress.Commands.add("startFreePlay", () => {
+  cy.visit("/");
+  cy.get('[data-cy="landing_btn_free_play"]').click();
+});

--- a/src/components/GuessDial.tsx
+++ b/src/components/GuessDial.tsx
@@ -10,12 +10,19 @@ import "../scenes/Game.module.scss";
 export interface GuessDialProps {
   guess: number;
   onUpdate: (angle: number) => void;
+
+  // set to true to disable interaction with the guess dial
+  disabled: boolean;
 }
 /**
  * GuessDial represents the game's guess dial SVG. It restricts its rotation
  * to the top half of a circle.
  */
-export const GuessDial = ({ guess, onUpdate }: GuessDialProps) => {
+export const GuessDial = ({
+  guess,
+  onUpdate,
+  disabled = false,
+}: GuessDialProps) => {
   // Restrict the rotation angle to -90° < θ < 90°, the top half of a circle
   // (keeping in mind that CSS transforms work clockwise
   // instead of the conventional counter-clockwise).
@@ -47,6 +54,7 @@ export const GuessDial = ({ guess, onUpdate }: GuessDialProps) => {
       onUpdate={onUpdate}
       onBeforeUpdate={restrictToUpperHalf}
       angle={guess}
+      disabled={disabled}
     />
   );
 };

--- a/src/components/RotatableImage.tsx
+++ b/src/components/RotatableImage.tsx
@@ -71,6 +71,9 @@ export interface RotatableImageProps {
   src: string;
   style?: CSSProperties;
   className: string;
+
+  // set to true to disable rotation
+  disabled: boolean;
   onUpdate?: (angle: number) => void;
   onBeforeUpdate?: (event: OnUpdatingEvent) => number;
 }
@@ -91,6 +94,7 @@ export const RotatableImage = ({
   onUpdate,
   onBeforeUpdate,
   angle = START_ANGLE,
+  disabled = false,
 }: RotatableImageProps) => {
   // editModedAngle saves the angle while this component is in 'edit mode'
   // (while the mouse is down)
@@ -131,7 +135,9 @@ export const RotatableImage = ({
   }, []);
 
   const startRotating = () => {
-    setIsRotating(true);
+    if (!disabled) {
+      setIsRotating(true);
+    }
   };
 
   const finishRotating = () => {

--- a/src/scenes/Landing.module.scss
+++ b/src/scenes/Landing.module.scss
@@ -12,14 +12,15 @@ button {
   width: 7rem;
 }
 
-.landingMenuContainer > button {
-  display: block;
+.landingMenuContainer > form {
   margin: 0 auto;
   margin-top: 70px;
 }
 
-#content2 {
-  padding-left: 10px;
+.landingMenuContainer > form > button {
+  margin: 0 auto;
+  margin-top: 15px;
+  display: block;
 }
 
 .topBar {

--- a/src/scenes/Landing.tsx
+++ b/src/scenes/Landing.tsx
@@ -2,6 +2,7 @@ import { customAlphabet, urlAlphabet } from "nanoid";
 import React from "react";
 import { useNavigate } from "react-router";
 import { removeFromLocalStorage } from "src/store/localStorage";
+import { GameMode } from "src/store/SharedState";
 import "./Landing.module.scss";
 
 /**
@@ -14,9 +15,20 @@ const generateId = customAlphabet(urlAlphabet, 4);
 export const Landing = () => {
   const navigate = useNavigate();
 
-  const onClick = () => {
+  const startNewGame = (mode: GameMode) => {
     removeFromLocalStorage();
-    navigate(`/${generateId()}`, { replace: true, state: { isNewGame: true } });
+    navigate(`/${generateId()}`, {
+      replace: true,
+      state: { isNewGame: true, mode },
+    });
+  };
+
+  const onStartMatchClick = () => {
+    startNewGame(GameMode.NORMAL);
+  };
+
+  const onFreePlayClick = () => {
+    startNewGame(GameMode.FREE_PLAY);
   };
 
   return (
@@ -35,9 +47,14 @@ export const Landing = () => {
         <p id="content2">
           Play with your friends across multiple devices on a shared board.
         </p>
-        <button data-cy="landing_btn_new_game" onClick={onClick}>
-          New Game
-        </button>
+        <form>
+          <button data-cy="landing_btn_new_game" onClick={onStartMatchClick}>
+            Start Match
+          </button>
+          <button data-cy="landing_btn_free_play" onClick={onFreePlayClick}>
+            Free Play
+          </button>
+        </form>
       </div>
     </>
   );

--- a/src/scenes/StoreContextProvider.tsx
+++ b/src/scenes/StoreContextProvider.tsx
@@ -9,6 +9,7 @@ import {
   readGameIdFromLocalStorage,
   removeFromLocalStorage,
 } from "src/store/localStorage";
+import { GameMode } from "src/store/SharedState";
 
 import { YStoreFactory } from "src/store/Store";
 
@@ -35,7 +36,8 @@ export const StoreContextProvider = () => {
   const yStoreFactory = new YStoreFactory({ id: gameId });
   const store = yStoreFactory.getStore(
     cachedSharedState,
-    !!location?.state?.isNewGame
+    !!location?.state?.isNewGame,
+    location?.state?.mode as GameMode
   );
 
   return (

--- a/src/scenes/game/Chadburn.tsx
+++ b/src/scenes/game/Chadburn.tsx
@@ -9,11 +9,14 @@ export interface ChadburnProps {
 
   showTarget: boolean;
   target: number;
+
+  disabled: boolean;
 }
 
 /**
  * Chadburn encapsulates the graphical parts of the game display: the guess dial,
- * the target overlay, and the border image.
+ * the target overlay, and the border image. Disabling it prevents players from
+ * moving the guess dial.
  *
  * The target can optionally be hidden e.g. for the player view.
  */
@@ -22,10 +25,11 @@ export const Chadburn = ({
   onGuessUpdate,
   showTarget,
   target,
+  disabled,
 }: ChadburnProps) => {
   return (
     <>
-      <GuessDial guess={guess} onUpdate={onGuessUpdate} />
+      <GuessDial guess={guess} onUpdate={onGuessUpdate} disabled={disabled} />
       <div
         style={{
           height: "153px",

--- a/src/scenes/game/Game.tsx
+++ b/src/scenes/game/Game.tsx
@@ -35,7 +35,7 @@ import {
   UpdateGuessAction,
   UpdateHintAction,
 } from "src/store/actions";
-import { SharedState } from "src/store/SharedState";
+import { GameMode, SharedState } from "src/store/SharedState";
 import "../Game.module.scss";
 
 interface GameProps {
@@ -124,7 +124,12 @@ export const Game = ({ sharedState, publish }: GameProps) => {
     }
   };
 
-  const gameOver = isGameOver(sharedState.game.score);
+  const gameOver =
+    isGameOver(sharedState.game.score) && sharedState.mode === GameMode.NORMAL;
+
+  // we want to disable the chadburn (prevent it from being rotated) when
+  // the turn summary is displayed
+  let chadburnDisabled = turnOver;
 
   /**
    * The current action form depends on the current actor, view, and
@@ -157,6 +162,8 @@ export const Game = ({ sharedState, publish }: GameProps) => {
     isGuessSubmitted(sharedState.game.turn) &&
     !isRebuttalSubmitted(sharedState.game.turn)
   ) {
+    // disable the chadburn during the rebuttal
+    chadburnDisabled = true;
     currentActionForm = (
       <RebuttalForm
         rebuttal={
@@ -166,6 +173,7 @@ export const Game = ({ sharedState, publish }: GameProps) => {
         otherTeam={getTeamOutOfTurn(sharedState.game)}
         onRebuttalUpdate={onRebuttalUpdate}
         onRebuttalSubmit={onRebuttalSubmit}
+        mode={sharedState.mode}
       />
     );
     currentActionFormVisible = isPlayer;
@@ -178,6 +186,7 @@ export const Game = ({ sharedState, publish }: GameProps) => {
       <TopBar />
       <div className="gameSceneContainer" draggable={false}>
         <Header
+          visible={sharedState.mode === GameMode.NORMAL}
           score={sharedState.game.score}
           teamInTurn={sharedState.game.teamInTurn}
         />
@@ -193,6 +202,7 @@ export const Game = ({ sharedState, publish }: GameProps) => {
               onGuessUpdate={onGuessUpdate}
               showTarget={!isPlayer || turnOver}
               target={sharedState.game.turn.target}
+              disabled={chadburnDisabled}
             />
           )}
         </div>
@@ -212,7 +222,12 @@ export const Game = ({ sharedState, publish }: GameProps) => {
         </div>
 
         <div
-          style={{ visibility: turnOver ? "visible" : "hidden" }}
+          style={{
+            visibility:
+              turnOver && sharedState.mode === GameMode.NORMAL
+                ? "visible"
+                : "hidden",
+          }}
           className="summary"
         >
           <Summary isTurnOver={turnOver} state={sharedState} />

--- a/src/scenes/game/Header.tsx
+++ b/src/scenes/game/Header.tsx
@@ -6,11 +6,16 @@ import { isGameOver, Score } from "src/game/game";
 interface HeaderProps {
   score: Score;
   teamInTurn: string;
+  visible: boolean;
 }
 
-export const Header = ({ score, teamInTurn }: HeaderProps) => {
+export const Header = ({ score, teamInTurn, visible }: HeaderProps) => {
   return (
-    <div className="header">
+    <div
+      style={{ visibility: visible ? "visible" : "hidden" }}
+      className="header"
+      data-cy="game_header"
+    >
       <p>
         <span style={{ color: "blue" }}>
           Blue: <span data-cy="game_score_blue">{score.get("blue")}</span>

--- a/src/scenes/game/RebuttalForm.tsx
+++ b/src/scenes/game/RebuttalForm.tsx
@@ -1,15 +1,38 @@
 import React from "react";
 import { Toggle } from "src/components/Toggle";
 import { Rebuttal, Rebuttals } from "src/game/turn";
+import { GameMode } from "src/store/SharedState";
 
 interface RebuttalViewProps {
   rebuttal: Rebuttal;
   teamInTurn: string;
   otherTeam: string;
 
+  mode: GameMode;
+
   onRebuttalUpdate: (rebuttal: Rebuttal) => void;
   onRebuttalSubmit: () => void;
 }
+
+/**
+ * Gets the rebuttal prompt based on the game mode.
+ * For normal matches, we want to include team names to make the instructions
+ * more clear. For free play games, we want to omit team information.
+ */
+const getPrompt = (teamInTurn: string, otherTeam: string, mode: GameMode) => {
+  if (mode === GameMode.NORMAL) {
+    return (
+      <>
+        <span style={{ color: otherTeam }}>{otherTeam} team</span>, does the
+        target lie to the left or the right of{" "}
+        <span style={{ color: teamInTurn }}>{teamInTurn} team&apos;s</span>{" "}
+        guess?
+      </>
+    );
+  }
+
+  return <>Does the target lie to the left or the right of the guess?</>;
+};
 
 export const RebuttalForm = ({
   rebuttal,
@@ -17,14 +40,12 @@ export const RebuttalForm = ({
   otherTeam,
   onRebuttalUpdate,
   onRebuttalSubmit,
+  mode = GameMode.NORMAL,
 }: RebuttalViewProps) => {
   return (
     <div>
-      <p className="formDescription">
-        <span style={{ color: otherTeam }}>{otherTeam} team</span>, does the
-        target lie to the left or the right of{" "}
-        <span style={{ color: teamInTurn }}>{teamInTurn} team&apos;s</span>{" "}
-        guess?
+      <p data-cy="game_prompt_rebuttal" className="formDescription">
+        {getPrompt(teamInTurn, otherTeam, mode)}
       </p>
       <div className="formInput">
         <Toggle

--- a/src/store/SharedState.ts
+++ b/src/store/SharedState.ts
@@ -1,6 +1,11 @@
 import { GameState } from "src/game/game";
 import { Rebuttal, Spectrum } from "src/game/turn";
 
+export enum GameMode {
+  NORMAL,
+  FREE_PLAY,
+}
+
 /**
  * SharedState is meant to be shared across all clients in the
  * same game. It includes the game state as well as 'edit mode' properties.
@@ -19,4 +24,6 @@ export interface SharedState {
   started: boolean;
 
   spectrumHistory: Array<Spectrum>;
+
+  mode: GameMode;
 }


### PR DESCRIPTION
Free play mode has is not scored and has no teams. Players must elect a psychic themselves.

Related changes:
- hide scoreboard
- do not display team names in the rebuttal prompt
- do not ever end the game

Other changes:
- margins of landing page text aligned
- disable guess dial during rebuttal and turn summary