### PR TITLE
adds height to the spectrum container

### DIFF
--- a/src/scenes/Game.module.scss
+++ b/src/scenes/Game.module.scss
@@ -47,6 +47,7 @@
 
 .spectrum {
   width: 300px;
+  height: 30px;
   display: inline-flex;
   justify-content: space-between;
   align-items: center;
@@ -54,18 +55,17 @@
 
 .spectrum > p {
   font-size: 0.8rem;
-  width: 100%;
   margin: 0 auto;
   padding-top: 5px;
 }
 
 .spectrum > #one {
-  width: 100px;
+  width: 90px;
   margin-left: -10px;
 }
 
 .spectrum > #two {
-  width: 100px;
+  width: 90px;
   text-align: right;
   margin-right: -10px;
 }


### PR DESCRIPTION
* I added height to the spectrum container so that when the text gets big it doesn't take more space moving the other elements in the page. So everything should be (kind of) in the same position all throughout the game. 