### PR TITLE
consolidating margins of the landing and game pages

### DIFF
--- a/src/Styles/App.scss
+++ b/src/Styles/App.scss
@@ -22,6 +22,7 @@ body {
 
 #app {
   margin: 0 auto;
+  padding: 24px;
   max-width: 525px;
 }
 

--- a/src/components/TopBar.module.scss
+++ b/src/components/TopBar.module.scss
@@ -1,15 +1,14 @@
 .title {
   margin: 0 auto;
   display: flex;
-  justify-content: space-between;
   align-items: center;
   height: 50px;
   margin-top: 40px;
-  padding: 0 40px;
 }
 
 .title > h1 {
   font-size: 30px;
+  margin-left: 0;
 }
 
 .title > h1 > a {
@@ -20,6 +19,8 @@
 .title > .clipboard {
   width: fit-content;
   border: none;
+  margin-left: auto;
+  margin-right: 0;
 
   &:before {
     visibility: hidden;

--- a/src/scenes/Game.module.scss
+++ b/src/scenes/Game.module.scss
@@ -123,16 +123,22 @@
   margin-top: -50px;
 }
 
-.actorToggleContainer {
+.footer {
   width: 100%;
   display: inline-flex;
-  justify-content: space-between;
   position: relative;
   z-index: 10;
-  margin-right: 20px;
-  margin-left: 10px;
   margin-bottom: 40px;
   align-items: center;
+}
+
+.footerLeft {
+  margin-left: 0;
+}
+
+.footerRight {
+  margin-left: auto;
+  margin-right: 0;
 }
 
 .endgameText {

--- a/src/scenes/game/Footer.tsx
+++ b/src/scenes/game/Footer.tsx
@@ -19,26 +19,28 @@ export const Footer = ({
   onNextTurnClick,
 }: FooterProps) => {
   return (
-    <div className="actorToggleContainer">
-      <a onClick={onNewGameClick} data-cy="btn_new_game">
+    <div className="footer">
+      <a className="footerLeft" onClick={onNewGameClick} data-cy="btn_new_game">
         New Game
       </a>
-      {isTurnOver ? (
-        <>
-          <a data-cy="btn_next_turn" onClick={onNextTurnClick}>
-            Next Turn{" "}
-          </a>
-        </>
-      ) : (
-        <>
-          <Toggle
-            left="Player"
-            right="Psychic"
-            isLeft={isPlayer}
-            onToggle={onActorToggle}
-          />
-        </>
-      )}
+      <div className="footerRight">
+        {isTurnOver ? (
+          <>
+            <a data-cy="btn_next_turn" onClick={onNextTurnClick}>
+              Next Turn{" "}
+            </a>
+          </>
+        ) : (
+          <>
+            <Toggle
+              left="Player"
+              right="Psychic"
+              isLeft={isPlayer}
+              onToggle={onActorToggle}
+            />
+          </>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/scenes/game/Game.tsx
+++ b/src/scenes/game/Game.tsx
@@ -233,15 +233,13 @@ export const Game = ({ sharedState, publish }: GameProps) => {
           <Summary isTurnOver={turnOver} state={sharedState} />
         </div>
 
-        <div className="actorToggleContainer">
-          <Footer
-            isPlayer={isPlayer}
-            onActorToggle={onActorToggle}
-            onNewGameClick={onNewGameClick}
-            isTurnOver={turnOver}
-            onNextTurnClick={onNextTurnClick}
-          />
-        </div>
+        <Footer
+          isPlayer={isPlayer}
+          onActorToggle={onActorToggle}
+          onNewGameClick={onNewGameClick}
+          isTurnOver={turnOver}
+          onNextTurnClick={onNextTurnClick}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
The goal is to make left and right alignment of items more consistent.

Now, the 'CHADBURN' title is left-aligned with the 'New Game' button, and the 'Next Turn' and role picker components are right-aligned with the 'Copy Link' button.