### PR TITLE
Switch all players to Player view after each turn completes

### DIFF
--- a/cypress/lib/Multiplayer.js
+++ b/cypress/lib/Multiplayer.js
@@ -90,4 +90,28 @@ export class MultiplayerClient {
   setSubmittedHint(hint) {
     this.store.publish({ type: ActionTypes.SUBMIT_HINT, hint });
   }
+
+  setSubmittedGuess(guess) {
+    this.store.publish({
+      type: ActionTypes.SUBMIT_GUESS,
+      guess: guess,
+    });
+  }
+
+  setSubmittedRebuttal(rebuttal) {
+    this.store.publish({
+      type: ActionTypes.SUBMIT_REBUTTAL,
+      rebuttal,
+    });
+  }
+
+  finishTurn() {
+    this.store.publish({
+      type: ActionTypes.FINISH_TURN,
+    });
+  }
+
+  startTurn() {
+    this.store.publish({ type: ActionTypes.START_TURN });
+  }
 }

--- a/src/scenes/game/Game.tsx
+++ b/src/scenes/game/Game.tsx
@@ -54,6 +54,11 @@ export const Game = ({ sharedState, publish }: GameProps) => {
     if (!sharedState.started) {
       publish({ type: ActionTypes.START_GAME });
     }
+
+    const turnOver = isTurnOver(sharedState.game.turn);
+    if (turnOver) {
+      setIsPlayer(true);
+    }
   }, [sharedState]);
 
   const onGuessUpdate = (guess: number) => {


### PR DESCRIPTION
This prevents the former Psychic from seeing the new turn's target