### PR TITLE
allow players to url hack their own game IDs

### DIFF
--- a/cypress/e2e/multiplayer.cy.js
+++ b/cypress/e2e/multiplayer.cy.js
@@ -1,7 +1,7 @@
 /// <reference types="Cypress" />
 
 import { getInitialSharedState } from "../../src/store/Store";
-import { modeCommands, Game } from "../lib/Game";
+import { Game, modeCommands } from "../lib/Game";
 import {
   getClientForAnotherPlayer,
   getDefaultSignalingUrl,
@@ -111,25 +111,30 @@ describe("multiplayer", () => {
     Psychic.submitsHint("a hint");
     Player.setsGuess(11);
 
+    const otherPlayerAlias = "other-player";
     const otherGameId = "otherGame";
-    const otherPlayer = getClientForAnotherPlayer(
-      otherGameId,
-      getDefaultSignalingUrl(),
-      getInitialSharedState(),
-      true
-    );
+    cy.wrap(
+      getClientForAnotherPlayer(
+        otherGameId,
+        getDefaultSignalingUrl(),
+        getInitialSharedState(),
+        true
+      )
+    ).as(otherPlayerAlias);
 
     const newGuess = 22;
     const newHint = "new hint";
-    otherPlayer.startGame();
-    otherPlayer.setGuess(newGuess);
-    otherPlayer.setSubmittedHint(newHint);
-    const spectrum = otherPlayer.getSpectrum();
+    cy.get(`@${otherPlayerAlias}`).then((otherPlayer) => {
+      otherPlayer.startGame();
+      otherPlayer.setGuess(newGuess);
+      otherPlayer.setSubmittedHint(newHint);
+      const spectrum = otherPlayer.getSpectrum();
 
-    cy.visit(`/${otherGameId}`);
+      cy.visit(`/${otherGameId}`);
 
-    Game.getGuessAngle().should("equal", newGuess);
-    Game.getSubmittedHint().should("equal", newHint);
-    Game.getSpectrum().should("deep.equal", spectrum);
+      Game.getGuessAngle().should("equal", newGuess);
+      Game.getSubmittedHint().should("equal", newHint);
+      Game.getSpectrum().should("deep.equal", spectrum);
+    });
   });
 });

--- a/cypress/lib/Multiplayer.js
+++ b/cypress/lib/Multiplayer.js
@@ -26,7 +26,7 @@ export function getDefaultSignalingUrl() {
  * @param {*} signalingUrl
  * @returns
  */
-export function getClientForAnotherPlayer(
+export async function getClientForAnotherPlayer(
   gameId,
   signalingUrl,
   initialState,
@@ -39,7 +39,7 @@ export function getClientForAnotherPlayer(
   });
 
   const factory = new YStoreFactory({ ydoc, id: gameId });
-  const store = factory.getStore(initialState, isNewGame);
+  const store = await factory.getStore(initialState, isNewGame);
 
   return new MultiplayerClient(store, ydoc, provider);
 }

--- a/src/scenes/StoreContextProvider.tsx
+++ b/src/scenes/StoreContextProvider.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import { useLocation, useParams } from "react-router";
+import { Loader } from "src/components/Loader";
 import { GameController } from "src/scenes/GameController";
 import { StoreContext } from "src/scenes/StoreContext";
 import {
@@ -11,38 +12,46 @@ import {
 } from "src/store/localStorage";
 import { GameMode } from "src/store/SharedState";
 
-import { YStoreFactory } from "src/store/Store";
+import { Store, YStoreFactory } from "src/store/Store";
 
 export const StoreContextProvider = () => {
   const { gameId } = useParams();
   const location = useLocation();
 
-  let cachedSharedState;
-  /**
-   * If the current game's ID matches the ID cached in local storage,
-   * then any cached shared state corresponds with the current game,
-   * so we can read it.
-   */
-  if (gameId === readGameIdFromLocalStorage()) {
-    cachedSharedState = readFromLocalStorage();
-  } else {
+  const [store, setStore] = useState<Store | undefined>();
+
+  useEffect(() => {
+    let cachedSharedState;
     /**
-     * Otherwise, clear the cached shared state and cache the current gameId.
+     * If the current game's ID matches the ID cached in local storage,
+     * then any cached shared state corresponds with the current game,
+     * so we can read it.
      */
-    removeFromLocalStorage();
-    cacheGameIdInLocalStorage(gameId);
-  }
+    if (gameId === readGameIdFromLocalStorage()) {
+      cachedSharedState = readFromLocalStorage();
+    } else {
+      /**
+       * Otherwise, clear the cached shared state and cache the current gameId.
+       */
+      removeFromLocalStorage();
+      cacheGameIdInLocalStorage(gameId);
+    }
 
-  const yStoreFactory = new YStoreFactory({ id: gameId });
-  const store = yStoreFactory.getStore(
-    cachedSharedState,
-    !!location?.state?.isNewGame,
-    location?.state?.mode as GameMode
-  );
+    const yStoreFactory = new YStoreFactory({ id: gameId });
+    yStoreFactory
+      .getStore(
+        cachedSharedState,
+        !!location?.state?.isNewGame,
+        location?.state?.mode as GameMode
+      )
+      .then((store) => setStore(store));
+  }, []);
 
-  return (
+  return !!store ? (
     <StoreContext.Provider value={store}>
       <GameController />
     </StoreContext.Provider>
+  ) : (
+    <Loader />
   );
 };


### PR DESCRIPTION
This is somewhat tricky to reason about and hacky to implement. If the user provides a game ID in the URL by hand without clicking the new game button, how do we know if they're trying to join a game, or if they're trying to start a new one?

With this solution, we wait 4 seconds to try to connecto to other players in the same game; if none are found after 4 seconds, we assume they are trying to start a new game.